### PR TITLE
feat(markdown-preview): add PDF export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "diff": "^8.0.2",
         "dompurify": "^3.3.0",
         "highlight.js": "^11.11.1",
+        "html2pdf.js": "^0.14.0",
         "js-yaml": "^4.1.1",
         "jsqr": "^1.4.0",
         "localforage": "^1.10.0",
@@ -303,9 +304,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2114,6 +2115,12 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/papaparse": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.0.tgz",
@@ -2133,6 +2140,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "19.1.11",
@@ -2579,6 +2593,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/bootstrap": {
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
@@ -2711,6 +2734,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2810,6 +2853,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2832,6 +2887,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-to-react-native": {
@@ -2925,9 +2989,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3258,6 +3322,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -3277,6 +3358,12 @@
         "set-cookie-parser": "^2.4.8",
         "tough-cookie": "^4.0.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3428,6 +3515,30 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/html2pdf.js": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.14.0.tgz",
+      "integrity": "sha512-yvNJgE/8yru2UeGflkPdjW8YEY+nDH5X7/2WG4uiuSCwYiCp8PZ8EKNiTAa6HxJ1NjC51fZSIEq6xld5CADKBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0",
+        "jspdf": "^4.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3477,6 +3588,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3590,6 +3707,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsqr": {
@@ -3952,6 +4086,13 @@
         "@napi-rs/canvas": "^1.0.0"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4100,6 +4241,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "19.1.1",
@@ -4259,6 +4410,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4299,6 +4457,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -4834,6 +5002,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4948,6 +5126,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/sync-child-process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
@@ -4969,6 +5157,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinyglobby": {
@@ -5188,6 +5385,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "diff": "^8.0.2",
     "dompurify": "^3.3.0",
     "highlight.js": "^11.11.1",
+    "html2pdf.js": "^0.14.0",
     "js-yaml": "^4.1.1",
     "jsqr": "^1.4.0",
     "localforage": "^1.10.0",

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, FC } from "react";
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { marked } from "marked";
 import { markedHighlight } from "marked-highlight";
 import hljs from "highlight.js";
@@ -15,26 +15,15 @@ import {
   FormGroup,
   Input,
   Row,
+  Spinner,
   Tooltip,
 } from "reactstrap";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { CopyIcon } from "./Images";
 import { useRevertableState } from "../utility/useRevertableState";
 
-const CustomTextarea = styled(Input)`
-  field-sizing: content;
-  min-height: 400px;
-  max-height: 600px;
-  font-family: monospace;
-`;
-
-const PreviewContainer = styled.div`
-  min-height: 400px;
-  max-height: 600px;
-  overflow-y: auto;
-  padding: 1rem;
-
-  /* GitHub-flavored styling */
+// Shared GitHub-flavored markdown styling, themed via Bootstrap CSS variables.
+const githubMarkdownStyles = css`
   h1, h2, h3, h4, h5, h6 {
     margin-top: 1.5rem;
     margin-bottom: 1rem;
@@ -135,6 +124,22 @@ const PreviewContainer = styled.div`
     max-width: 100%;
     height: auto;
   }
+`;
+
+const CustomTextarea = styled(Input)`
+  field-sizing: content;
+  min-height: 400px;
+  max-height: 600px;
+  font-family: monospace;
+`;
+
+const PreviewContainer = styled.div`
+  min-height: 400px;
+  max-height: 600px;
+  overflow-y: auto;
+  padding: 1rem;
+
+  ${githubMarkdownStyles}
 `;
 
 const FullscreenOverlay = styled.div<{ isOpen: boolean }>`
@@ -167,106 +172,62 @@ const FullscreenPreview = styled.div`
   margin: 0 auto;
   width: 100%;
 
-  /* Same GitHub-flavored styling as PreviewContainer */
-  h1, h2, h3, h4, h5, h6 {
-    margin-top: 1.5rem;
-    margin-bottom: 1rem;
-    font-weight: 600;
-    line-height: 1.25;
-  }
+  ${githubMarkdownStyles}
+`;
 
-  h1 {
-    font-size: 2rem;
-    border-bottom: 1px solid var(--bs-border-color);
-    padding-bottom: 0.3rem;
-  }
+// Off-screen container rendered with explicit light-theme colors so the
+// exported PDF is legible regardless of the app's active theme.
+const PdfContent = styled.div`
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  width: 800px;
+  padding: 40px;
+  background-color: #ffffff;
+  color: #1f2328;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
+    sans-serif;
 
+  ${githubMarkdownStyles}
+
+  /* Explicit light-theme overrides applied after the shared (theme-variable)
+     styles so they win regardless of the app's active Bootstrap theme. */
+  h6 { color: #59636e; }
+
+  h1,
   h2 {
-    font-size: 1.5rem;
-    border-bottom: 1px solid var(--bs-border-color);
-    padding-bottom: 0.3rem;
-  }
-
-  h3 { font-size: 1.25rem; }
-  h4 { font-size: 1rem; }
-  h5 { font-size: 0.875rem; }
-  h6 { font-size: 0.85rem; color: var(--bs-secondary-color); }
-
-  p {
-    margin-bottom: 1rem;
-  }
-
-  ul, ol {
-    padding-left: 2rem;
-    margin-bottom: 1rem;
-  }
-
-  li {
-    margin-bottom: 0.25rem;
+    border-bottom: 1px solid #d0d7de;
   }
 
   code {
-    background-color: rgba(110, 118, 129, 0.2);
-    padding: 0.2rem 0.4rem;
-    border-radius: 3px;
-    font-size: 85%;
+    background-color: rgba(129, 139, 152, 0.2);
   }
 
+  /* Keep code blocks dark to match the github-dark highlight theme. */
   pre {
-    background-color: #0d1117;
-    padding: 1rem;
-    border-radius: 6px;
-    overflow-x: auto;
-    margin-bottom: 1rem;
-  }
-
-  pre code {
-    padding: 0;
-    background-color: transparent;
+    color: #e6edf3;
   }
 
   blockquote {
-    padding: 0 1rem;
-    border-left: 0.25rem solid var(--bs-border-color);
-    color: var(--bs-secondary-color);
-    margin-bottom: 1rem;
+    border-left: 0.25rem solid #d0d7de;
+    color: #59636e;
   }
 
   hr {
-    border: 0;
-    border-top: 1px solid var(--bs-border-color);
-    margin: 1.5rem 0;
-  }
-
-  table {
-    border-collapse: collapse;
-    width: 100%;
-    margin-bottom: 1rem;
+    border-top: 1px solid #d0d7de;
   }
 
   table th,
   table td {
-    padding: 0.5rem;
-    border: 1px solid var(--bs-border-color);
+    border: 1px solid #d0d7de;
   }
 
   table th {
-    background-color: rgba(110, 118, 129, 0.1);
-    font-weight: 600;
+    background-color: #f6f8fa;
   }
 
   a {
-    color: var(--bs-link-color);
-    text-decoration: none;
-  }
-
-  a:hover {
-    text-decoration: underline;
-  }
-
-  img {
-    max-width: 100%;
-    height: auto;
+    color: #0969da;
   }
 `;
 
@@ -366,7 +327,9 @@ export const MarkdownPreview: FC = () => {
   const [markdown, setMarkdown] = useState<string>(defaultMarkdown);
   const [viewMode, setViewMode] = useState<ViewMode>("split");
   const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
+  const [isExporting, setIsExporting] = useState<boolean>(false);
   const [tooltipOpen, setTooltipOpen] = useRevertableState<boolean>(false, 2000);
+  const pdfRef = useRef<HTMLDivElement>(null);
 
   const handleMarkdownChange = ({ currentTarget }: ChangeEvent<HTMLInputElement>) => {
     setMarkdown(currentTarget.value);
@@ -384,6 +347,27 @@ export const MarkdownPreview: FC = () => {
 
   const handleClear = () => {
     setMarkdown("");
+  };
+
+  const handleExportPdf = async () => {
+    if (!pdfRef.current || isExporting) return;
+    setIsExporting(true);
+    try {
+      const { default: html2pdf } = await import("html2pdf.js");
+      await html2pdf()
+        .set({
+          margin: [10, 10, 10, 10],
+          filename: "markdown.pdf",
+          image: { type: "jpeg", quality: 0.98 },
+          html2canvas: { scale: 2, useCORS: true, backgroundColor: "#ffffff" },
+          jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
+          enableLinks: true,
+        })
+        .from(pdfRef.current)
+        .save();
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   const toggleFullscreen = () => {
@@ -442,6 +426,17 @@ export const MarkdownPreview: FC = () => {
             </Button>
           </Col>
           <Col xs="auto">
+            <Button color="secondary" onClick={handleExportPdf} disabled={isExporting}>
+              {isExporting ? (
+                <>
+                  <Spinner size="sm" /> Exporting…
+                </>
+              ) : (
+                "⬇ Export PDF"
+              )}
+            </Button>
+          </Col>
+          <Col xs="auto">
             <Button color="primary" onClick={handleCopyHtml} id="copyHtmlTooltip">
               <CopyIcon /> Copy HTML
             </Button>
@@ -492,6 +487,9 @@ export const MarkdownPreview: FC = () => {
         </FullscreenHeader>
         <FullscreenPreview dangerouslySetInnerHTML={{ __html: html }} />
       </FullscreenOverlay>
+
+      {/* Off-screen, light-themed render source for PDF export */}
+      <PdfContent ref={pdfRef} dangerouslySetInnerHTML={{ __html: html }} />
     </>
   );
 };


### PR DESCRIPTION
Add an "Export PDF" button to the Markdown Preview tool. The rendered
markdown is exported to a downloadable PDF using html2pdf.js (jsPDF +
html2canvas).

- Render from an off-screen, light-themed container so the PDF is legible
  regardless of the app's active theme, keeping code blocks dark to match
  the github-dark highlight theme.
- Dynamically import html2pdf.js on click so it is split into its own chunk
  and does not bloat the initial Markdown Preview load.
- Show a spinner and disable the button while exporting.
- Factor the duplicated GitHub-flavored markdown CSS into a shared
  styled-components block reused by the preview, fullscreen, and PDF views.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JpkCRnJxhUDRozU9zt9xca